### PR TITLE
Add group chat support

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -5,4 +5,4 @@ set -e
 npm install
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
-exec node_modules/.bin/hubot --name "sehero" "$@"
+exec node_modules/.bin/hubot -n $TELEGRAM_BOT_NAME -l / "$@"

--- a/bin/hubot.cmd
+++ b/bin/hubot.cmd
@@ -4,4 +4,4 @@ call npm install
 SETLOCAL
 SET PATH=node_modules\.bin;node_modules\hubot\node_modules\.bin;%PATH%
 
-node_modules\.bin\hubot.cmd --name "sehero" %* 
+node_modules\.bin\hubot.cmd -n %TELEGRAM_BOT_NAME% -l / %*


### PR DESCRIPTION
Note: The command line now uses an environment variable `TELEGRAM_BOT_NAME` as the bot's name, to avoid name conflict.
